### PR TITLE
🧹 Refactor hardcoded LocalStorage keys to constants

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { InterviewSimulator } from './components/InterviewSimulator';
 import { ResultsView } from './components/ResultsView';
 import { Dashboard } from './components/Dashboard';
 import { calculateNextReview, scoreToPerformance } from './utils/srs';
+import { STORAGE_KEYS } from './constants';
 import questionsData from '../data/questions.json';
 
 type AppState = 'setup' | 'interview' | 'results' | 'dashboard';
@@ -20,11 +21,11 @@ function App() {
   const [sessionStartTime, setSessionStartTime] = useState<number>(0);
 
   useEffect(() => {
-    const savedProgress = localStorage.getItem('electrician-progress');
+    const savedProgress = localStorage.getItem(STORAGE_KEYS.PROGRESS);
     if (savedProgress) {
       setUserProgress(JSON.parse(savedProgress));
     }
-    const savedSessions = localStorage.getItem('electrician-sessions');
+    const savedSessions = localStorage.getItem(STORAGE_KEYS.SESSIONS);
     if (savedSessions) {
       setSessions(JSON.parse(savedSessions));
     }
@@ -71,7 +72,7 @@ function App() {
 
     const updatedSessions = [newSession, ...sessions];
     setSessions(updatedSessions);
-    localStorage.setItem('electrician-sessions', JSON.stringify(updatedSessions));
+    localStorage.setItem(STORAGE_KEYS.SESSIONS, JSON.stringify(updatedSessions));
 
     // Update SRS progress
     const newProgress = { ...userProgress };
@@ -82,7 +83,7 @@ function App() {
     });
 
     setUserProgress(newProgress);
-    localStorage.setItem('electrician-progress', JSON.stringify(newProgress));
+    localStorage.setItem(STORAGE_KEYS.PROGRESS, JSON.stringify(newProgress));
 
     setState('results');
   };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export const STORAGE_KEYS = {
+  PROGRESS: 'electrician-progress',
+  SESSIONS: 'electrician-sessions',
+} as const;


### PR DESCRIPTION
**What:** Refactored hardcoded LocalStorage keys `'electrician-progress'` and `'electrician-sessions'` into a centralized `STORAGE_KEYS` object in `src/constants.ts`.

**Why:** To improve code maintainability, prevent typo-related bugs, and provide a single source of truth for storage keys.

**Verification:** Verified the changes by running `npm run build` and manually inspecting the code to ensure the keys are correctly replaced.

**Result:** The code is now cleaner and more robust against potential errors.

---
*PR created automatically by Jules for task [5645496002637887145](https://jules.google.com/task/5645496002637887145) started by @Turbo-the-tech-dev*