### PR TITLE
🔒 Fix sensitive transcript storage vulnerability

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { InterviewSimulator } from './components/InterviewSimulator';
 import { ResultsView } from './components/ResultsView';
 import { Dashboard } from './components/Dashboard';
 import { calculateNextReview, scoreToPerformance } from './utils/srs';
+import { sanitizeSession } from './utils/security';
 import questionsData from '../data/questions.json';
 
 type AppState = 'setup' | 'interview' | 'results' | 'dashboard';
@@ -69,7 +70,8 @@ function App() {
       score: averageScore
     };
 
-    const updatedSessions = [newSession, ...sessions];
+    const sanitizedSession = sanitizeSession(newSession);
+    const updatedSessions = [sanitizedSession, ...sessions];
     setSessions(updatedSessions);
     localStorage.setItem('electrician-sessions', JSON.stringify(updatedSessions));
 

--- a/src/utils/security.test.ts
+++ b/src/utils/security.test.ts
@@ -1,0 +1,43 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { sanitizeSession } from './security.ts';
+import type { InterviewSession, InterviewQuestion } from '../types.ts';
+
+test('sanitizeSession removes sensitive fields', () => {
+  const mockQuestion: InterviewQuestion = {
+    id: 'q1',
+    category: 'NEC code',
+    difficulty: 'apprentice',
+    question: 'What is NEC?',
+    answer: 'National Electrical Code',
+    keywords: ['code'],
+    points: 10,
+    userAnswer: 'It is a code',
+    transcription: 'it is a code',
+    isCorrect: true
+  };
+
+  const mockSession: InterviewSession = {
+    id: '123',
+    date: Date.now(),
+    startTime: 1000,
+    endTime: 2000,
+    score: 80,
+    questions: [mockQuestion]
+  };
+
+  const sanitized = sanitizeSession(mockSession);
+
+  // Check that sensitive fields are removed
+  assert.strictEqual((sanitized.questions[0] as any).userAnswer, undefined);
+  assert.strictEqual((sanitized.questions[0] as any).transcription, undefined);
+
+  // Check that other fields are preserved
+  assert.strictEqual(sanitized.questions[0].id, 'q1');
+  assert.strictEqual(sanitized.questions[0].points, 10);
+  assert.strictEqual(sanitized.id, '123');
+  assert.strictEqual(sanitized.questions[0].isCorrect, true);
+
+  // Ensure original object is not mutated
+  assert.strictEqual(mockSession.questions[0].userAnswer, 'It is a code');
+});

--- a/src/utils/security.ts
+++ b/src/utils/security.ts
@@ -1,0 +1,21 @@
+import type { InterviewSession, InterviewQuestion } from '../types';
+
+/**
+ * Sanitizes an interview session by removing sensitive user input (transcripts and answers).
+ * This ensures that personal information is not stored in localStorage, mitigating XSS risks.
+ *
+ * @param session The full interview session object
+ * @returns A new session object with sensitive fields removed from questions
+ */
+export const sanitizeSession = (session: InterviewSession): InterviewSession => {
+  const sanitizedQuestions = session.questions.map((q) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { userAnswer, transcription, ...rest } = q;
+    return rest as InterviewQuestion;
+  });
+
+  return {
+    ...session,
+    questions: sanitizedQuestions
+  };
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
🎯 **What:** Implemented `sanitizeSession` utility to remove `transcription` and `userAnswer` fields from interview sessions before persisting them to `localStorage`.
⚠️ **Risk:** Storing sensitive interview transcripts in `localStorage` exposes them to XSS attacks and unauthorized access if the device is shared.
🛡️ **Solution:**
- Created `src/utils/security.ts` with `sanitizeSession` function.
- Updated `src/App.tsx` to sanitize new sessions before saving.
- Added `src/utils/security.test.ts` to verify sanitization logic.
- Updated `tsconfig.json` to exclude test files from the build.

This ensures user privacy and reduces the attack surface without affecting the analytics dashboard.

---
*PR created automatically by Jules for task [9333121696147401051](https://jules.google.com/task/9333121696147401051) started by @Turbo-the-tech-dev*