### PR TITLE
🧹 Refactor duplicate category list to shared constant

### DIFF
--- a/src/components/CategorySelector.tsx
+++ b/src/components/CategorySelector.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Category, Difficulty } from '../types';
+import { CATEGORIES } from '../constants';
 
 interface CategorySelectorProps {
   selectedCategories: Category[];
@@ -8,10 +9,6 @@ interface CategorySelectorProps {
   setSelectedDifficulty: (difficulty: Difficulty) => void;
   onStart: () => void;
 }
-
-const CATEGORIES: Category[] = [
-  'NEC code', 'theory', 'practical', 'safety', 'troubleshooting', 'management', 'behavioral', 'scenario'
-];
 
 const DIFFICULTIES: Difficulty[] = ['apprentice', 'journeyman', 'master'];
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { InterviewSession, UserProgress, Category } from '../types';
+import { CATEGORIES } from '../constants';
 import { BarChart, TrendingUp, AlertTriangle, Lightbulb, Download, Calendar } from 'lucide-react';
 
 interface DashboardProps {
@@ -9,11 +10,7 @@ interface DashboardProps {
 
 export const Dashboard: React.FC<DashboardProps> = ({ sessions, userProgress }) => {
   // 1. Data Processing Logic
-  const categories: Category[] = [
-    'NEC code', 'theory', 'practical', 'safety', 'troubleshooting', 'management', 'behavioral', 'scenario'
-  ];
-
-  const categoryStats = categories.map(cat => {
+  const categoryStats = CATEGORIES.map(cat => {
     let totalPoints = 0;
     let count = 0;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,12 @@
+import type { Category } from './types';
+
+export const CATEGORIES: Category[] = [
+  'NEC code',
+  'theory',
+  'practical',
+  'safety',
+  'troubleshooting',
+  'management',
+  'behavioral',
+  'scenario'
+];


### PR DESCRIPTION
*   🎯 **What:** Extracted the hardcoded `categories` list from `src/components/Dashboard.tsx` and `src/components/CategorySelector.tsx` into a shared constant `CATEGORIES` in `src/constants.ts`.
*   💡 **Why:** This removes code duplication, ensuring that any future changes to the category list only need to be made in one place, improving maintainability and reducing the risk of inconsistencies.
*   ✅ **Verification:** Verified that the frontend still renders categories correctly in both the Category Selector and Dashboard using a Playwright script and screenshot validation. Also confirmed that the project builds successfully with `npm run build`.
*   ✨ **Result:** A cleaner codebase with a single source of truth for interview categories.

---
*PR created automatically by Jules for task [9544853630442086735](https://jules.google.com/task/9544853630442086735) started by @Turbo-the-tech-dev*