### PR TITLE
test: Add tests for calculateScore partial keyword matches

### DIFF
--- a/src/utils/scoring.test.ts
+++ b/src/utils/scoring.test.ts
@@ -53,4 +53,25 @@ describe('calculateScore', () => {
     const score = calculateScore(transcription, keywords);
     assert.strictEqual(score, 100);
   });
+
+  it('should match keywords as substrings', () => {
+    const transcription = 'The generator is running';
+    const keywords = ['gen', 'run'];
+    const score = calculateScore(transcription, keywords);
+    assert.strictEqual(score, 100);
+  });
+
+  it('should handle partial keyword matches within larger words', () => {
+    const transcription = 'concatenation';
+    const keywords = ['cat', 'nation'];
+    const score = calculateScore(transcription, keywords);
+    assert.strictEqual(score, 100);
+  });
+
+  it('should not match if substring is not present', () => {
+    const transcription = 'The generator is running';
+    const keywords = ['xyz', 'abc'];
+    const score = calculateScore(transcription, keywords);
+    assert.strictEqual(score, 0);
+  });
 });


### PR DESCRIPTION
Added unit tests to src/utils/scoring.test.ts to verify that the scoring logic correctly handles partial keyword matches (substrings). This ensures that scoring is flexible and robust as intended.
🎯 **What:** Added tests for partial keyword matching (substrings) in `calculateScore`.
📊 **Coverage:** Scenarios covered:
  - Substring match (e.g., 'gen' in 'generator')
  - Partial match within larger words (e.g., 'cat' in 'concatenation')
  - No match for non-existent substrings
✨ **Result:** Verified that the scoring logic supports flexible keyword matching as expected.

---
*PR created automatically by Jules for task [7693739082741876656](https://jules.google.com/task/7693739082741876656) started by @Turbo-the-tech-dev*