### PR TITLE
🔒 Add Content Security Policy to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self';">
     <title>Electrician Interview Prep</title>
   </head>
   <body>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,6 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src"],
+  "exclude": ["src/**/*.test.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
This PR addresses a security vulnerability by adding a Content Security Policy (CSP) to the `index.html` file.

**Changes:**
- Added `<meta http-equiv="Content-Security-Policy" ...>` to `index.html`.
- The CSP is configured to allow:
    - Scripts: 'self', 'unsafe-inline', 'unsafe-eval' (Required for Vite dev server and HMR)
    - Styles: 'self', 'unsafe-inline' (Required for React inline styles)
    - Images/Fonts: 'self', 'data:'
    - Connect: 'self'
    - Default: 'self'
- Updated `tsconfig.json` to exclude `src/**/*.test.ts` to fix build errors caused by test files being included in the production build compilation.

**Verification:**
- Validated that `npm run build` succeeds.
- Verified that the application loads correctly without CSP errors using a Playwright script.
- Confirmed that external resources (if any were added in the future) would be blocked by default.

---
*PR created automatically by Jules for task [1236297712911623810](https://jules.google.com/task/1236297712911623810) started by @Turbo-the-tech-dev*